### PR TITLE
Tweak Link headers (strip base url, combine, use content type)

### DIFF
--- a/Plugin/GroupedCollection.php
+++ b/Plugin/GroupedCollection.php
@@ -6,7 +6,6 @@ namespace Yireo\ServerPush\Plugin;
 
 use Magento\Framework\View\Asset\AssetInterface;
 use Magento\Framework\View\Asset\GroupedCollection as Subject;
-use Zend\Http\Header\GenericMultiHeader;
 
 /**
  * Class GroupedCollection


### PR DESCRIPTION
This combines a few changes:

 - Strip the base url domain from the url to save bytes
 - Use the content type to set the headers
 - Combine headers in 1 header, to avoid `headers()` function (which isn't okay to use with Response objects)
 - Fix url format