### PR TITLE
Construct link according to W3 specs, including crossorigin on fonts

### DIFF
--- a/Plugin/ResponsePlugin.php
+++ b/Plugin/ResponsePlugin.php
@@ -203,6 +203,8 @@ class ResponsePlugin
     }
 
     /**
+     * Construct link according to W3 specs, see https://www.w3.org/TR/preload/
+     *
      * @param string $link
      * @param string $type
      * @throws NoSuchEntityException
@@ -211,7 +213,17 @@ class ResponsePlugin
     {
         $link = $this->prepareLink($link);
         if (!empty($link)) {
-            $this->values[] = "<" . $link . ">; rel=preload; as=" . $type;
+            $newValue = [
+                '<' . $link . '>',
+                'rel=preload',
+                'as=' . $type,
+            ];
+
+            if ($type === 'font') {
+                $newValue[] = 'crossorigin=anonymous';
+            }
+
+            $this->values[] = implode('; ', $newValue);
         }
     }
 


### PR DESCRIPTION
Fonts need an additional crossorigin tag, otherwise the browser (chrome in my case) will not preload it due to security reasons. This PR adds "crossorigin=anonymous" to every font link.