### PR TITLE
fix: missing crossorigin in html output

### DIFF
--- a/Link/LinkParser.php
+++ b/Link/LinkParser.php
@@ -110,7 +110,13 @@ class LinkParser
                 continue;
             }
 
-            $newTags[] = '<link rel="preload" as="' . $link->getType() . '" href="' . $link->getUrl() . '" />';
+            $createTag = '<link rel="preload" as="' . $link->getType() . '"';
+            if ($link->getType() === 'font') {
+                $createTag .= ' crossorigin="anonymous"';
+            }
+            $createTag .= ' href="' . $link->getUrl() . '" />';
+
+            $newTags[] = $createTag;
         }
 
         $body = preg_replace('^</title>^',"</title>\n" . implode("\n", $newTags) , $body, 1);


### PR DESCRIPTION
I can see the support of crossorigin attribute in header but not in the html ouput :    
[/vendor/yireo/magento2-linkpreload/Link/Link.php
function getHeader](https://github.com/yireo/Yireo_LinkPreload/blob/15397c95266f5c4f1f8cdc25622df26aab0dddcc/Link/Link.php#L70)

But in the navigator, I have a notice in web developer :

> A preload for '../Blank-Theme-Icons/Blank-Theme-Icons.woff2' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.

This is my proposal to fix this issue.