### PR TITLE
Only preload CSS when critical CSS is disabled

### DIFF
--- a/Config/Config.php
+++ b/Config/Config.php
@@ -69,4 +69,12 @@ class Config
     {
         return (bool)$this->moduleList->has($module);
     }
+    
+    /**
+     * @return bool
+     */
+    public function isCriticalEnabled(): bool
+    {
+        return (bool)$this->scopeConfig->getValue('dev/css/use_css_critical_path');
+    }
 }

--- a/Link/LinkParser.php
+++ b/Link/LinkParser.php
@@ -142,7 +142,9 @@ class LinkParser
     {
         $crawler = new Crawler((string)$response->getContent());
 
-        $this->addStylesheetsAsLinkHeader($crawler->filter('link[rel="stylesheet"]'));
+        if (!$this->config->isCriticalEnabled()) {
+            $this->addStylesheetsAsLinkHeader($crawler->filter('link[rel="stylesheet"]'));
+        }
         $this->addScriptsAsLinkHeader($crawler->filter('script[type="text/javascript"][src]'));
 
         if ($this->config->skipImages() === false) {


### PR DESCRIPTION
Since the idea behind preloading is to fetch files that are going to be needed early on the rendering process, it makes sense to only preload the CSS when critical CSS is not used. Since critical CSS is already being loaded, we can delay the loading of CSS and load more important files earlier.