### PR TITLE
Loosen symfony/dom-crawler constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "magento/framework": "^102.0|^103.0",
     "magento/module-store": "^100.0|^101.0",
-    "symfony/dom-crawler": "^2.7|^3.0|^4.0",
+    "symfony/dom-crawler": "^2.7|^3.0|^4.0|^5.0",
     "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0",
     "php": ">=7.1"
   },


### PR DESCRIPTION
With Magento 2.4.4 and PHP 8.1 I have currently symfony/dom-crawler 5.4.9 installed.
Doesn't seem there are any major BC breaks from dom crawler 4 to 5 so I don't expect any issues. But maybe you can verify?