### PR TITLE
Only use HTML5 based parser when PHP >= 8.4

### DIFF
--- a/Link/LinkParser.php
+++ b/Link/LinkParser.php
@@ -140,7 +140,7 @@ class LinkParser
      */
     private function addLinkHeadersFromResponse(HttpResponse $response)
     {
-        $crawler = new Crawler((string)$response->getContent());
+        $crawler = new Crawler((string)$response->getContent(), useHtml5Parser: PHP_VERSION_ID >= 80400);
 
         if (!$this->config->isCriticalEnabled()) {
             $this->addStylesheetsAsLinkHeader($crawler->filter('link[rel="stylesheet"]'));

--- a/Link/LinkParser.php
+++ b/Link/LinkParser.php
@@ -2,6 +2,7 @@
 
 namespace Yireo\LinkPreload\Link;
 
+use Composer\InstalledVersions;
 use Magento\Framework\App\Response\Http as HttpResponse;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\View\Asset\Repository;
@@ -140,7 +141,8 @@ class LinkParser
      */
     private function addLinkHeadersFromResponse(HttpResponse $response)
     {
-        $crawler = new Crawler((string)$response->getContent(), useHtml5Parser: PHP_VERSION_ID >= 80400);
+        $useHtml5Parser = PHP_VERSION_ID >= 80400 && version_compare(InstalledVersions::getVersion('symfony/dom-crawler'), '7.4') >= 0;
+        $crawler = new Crawler((string)$response->getContent(), useHtml5Parser: $useHtml5Parser);
 
         if (!$this->config->isCriticalEnabled()) {
             $this->addStylesheetsAsLinkHeader($crawler->filter('link[rel="stylesheet"]'));


### PR DESCRIPTION
When using PHP 8.4 and symfony/dom-crawler 7.4 we can use the HTML 5 parser, otherwise its too expensive for the relative non importance and correctness requirements of this module.

60ms improvement for artificial example:

<img width="858" height="655" alt="Bildschirmfoto 2025-09-05 um 16 11 13" src="https://github.com/user-attachments/assets/3b627bb7-f626-4557-a471-1076d6702579" />

https://app.tideways.io/share/trace/602f2927-ce09-43b7-8777-37c5974326db/compare/491e2dad-90b8-465a-ae35-74ef074a1231

Fixes #48 